### PR TITLE
Fix ID-related bugs

### DIFF
--- a/components/AccountField.tsx
+++ b/components/AccountField.tsx
@@ -2,7 +2,7 @@ import { ChangeEventHandler } from "react"
 import { FaTrash } from "react-icons/fa"
 
 export interface Account {
-  'id': number
+  'id': string
   'pubKey': string,
   'signer': boolean,
   'writable': boolean

--- a/components/DataField.tsx
+++ b/components/DataField.tsx
@@ -3,7 +3,7 @@ import { FaTrash } from "react-icons/fa"
 import { ChangeEventHandler } from "react"
 
 export interface Data {
-  'id': number
+  'id': string
   'type': string
   'value': string
 }

--- a/components/Instruction.tsx
+++ b/components/Instruction.tsx
@@ -3,23 +3,23 @@ import DataField, { Data, dataTypes } from './DataField'
 import styles from '../styles/Instruction.module.css'
 import { ChangeEventHandler, MouseEventHandler, useState } from 'react'
 import { FaPlus, FaTrash } from 'react-icons/fa'
+import { v4 as uuidv4 } from 'uuid';
 
 export interface InstructionType {
-  'id': number,
+  'id': string,
   'programId': string,
   'accounts': Account[],
   'data': Data[]
 }
 
-function Instruction({ instruction, editInstruction, deleteInstruction, showDelete }: {
+function Instruction({ instruction, editInstruction, deleteInstruction, showDelete, index }: {
   instruction: InstructionType,
   editInstruction: Function,
   deleteInstruction: Function,
-  showDelete: boolean
+  showDelete: boolean,
+  index: number
 }) {
   const [reveal, setReveal] = useState(true);
-  const [nextAccountId, setNextAccountId] = useState(2);
-  const [nextDataId, setNextDataId] = useState(2);
 
   const onReveal = () => {
     setReveal(!reveal)
@@ -28,23 +28,21 @@ function Instruction({ instruction, editInstruction, deleteInstruction, showDele
   const addAccount: MouseEventHandler = (e) => {
     e.preventDefault();
     instruction.accounts.push({
-      id: nextAccountId,
+      id: uuidv4(),
       pubKey: '',
       signer: false,
       writable: false
     });
-    setNextAccountId(nextAccountId + 1);
     editInstruction(instruction)
   };
 
   const addData: MouseEventHandler = (e) => {
     e.preventDefault();
     instruction.data.push({
-      id: nextDataId,
+      id: uuidv4(),
       type: Object.keys(dataTypes)[0],
       value: ''
     });
-    setNextDataId(nextDataId + 1);
     editInstruction(instruction)
   };
 
@@ -60,7 +58,7 @@ function Instruction({ instruction, editInstruction, deleteInstruction, showDele
     editInstruction(instruction)
   };
 
-  const handleDeleteAccount = (id: number) => {
+  const handleDeleteAccount = (id: string) => {
     instruction.accounts = instruction.accounts.filter((acc) =>
       acc.id !== id
     )
@@ -74,7 +72,7 @@ function Instruction({ instruction, editInstruction, deleteInstruction, showDele
     editInstruction(instruction)
   };
 
-  const handleDeleteData = (id: number) => {
+  const handleDeleteData = (id: string) => {
     instruction.data = instruction.data.filter((d) =>
       d.id !== id
     )
@@ -85,7 +83,7 @@ function Instruction({ instruction, editInstruction, deleteInstruction, showDele
     <div className="collapse collapse-arrow">
       <input type="checkbox" checked={reveal} onChange={onReveal} />
       <h2 className="font-bold text-white collapse-title flex flex-row items-center">
-        Instruction {instruction.id}
+        Instruction {index}
       </h2>
       <div className={`collapse-content ${styles.instruction}`}>
         {showDelete ?

--- a/components/Instructions.tsx
+++ b/components/Instructions.tsx
@@ -5,13 +5,14 @@ function Instructions({ instructions, editInstruction, deleteInstruction }: {
   editInstruction: Function,
   deleteInstruction: Function
 }) {
-  const instructionElements = instructions.map(instruction =>
+  const instructionElements = instructions.map((instruction, index) =>
     <Instruction
       key={instruction.id}
       instruction={instruction}
       editInstruction={editInstruction}
       deleteInstruction={deleteInstruction}
       showDelete={instructions.length > 1}
+      index={index + 1}
     />);
 
   return (

--- a/components/TransactionForm.tsx
+++ b/components/TransactionForm.tsx
@@ -6,6 +6,7 @@ import { useState, MouseEventHandler, useEffect } from 'react'
 import { dataTypes } from './DataField'
 import { PublicKey, Transaction, TransactionInstruction } from '@solana/web3.js';
 import { struct } from '@solana/buffer-layout';
+import { v4 as uuidv4 } from 'uuid';
 
 interface Props {
   preset: String;
@@ -15,20 +16,20 @@ interface Props {
 function TransactionForm({ preset, updateResult }: Props) {
   const { publicKey } = useWallet()
 
-  const createTransferInstruction = (id: number): InstructionType => {
+  const createTransferInstruction = (id: string): InstructionType => {
 
     return {
       'id': id,
       'programId': '11111111111111111111111111111111',
       'accounts': [
         {
-          id: 1,
-          pubKey: publicKey?.toBase58() || ' ',
+          id: uuidv4(),
+          pubKey: publicKey?.toBase58() || '',
           signer: true,
           writable: true
         },
         {
-          id: 2,
+          id: uuidv4(),
           pubKey: '',
           signer: false,
           writable: true
@@ -36,12 +37,12 @@ function TransactionForm({ preset, updateResult }: Props) {
       ],
       'data': [
         {
-          id: 1,
+          id: uuidv4(),
           type: Object.keys(dataTypes)[2],
           value: '2'
         },
         {
-          id: 2,
+          id: uuidv4(),
           type: Object.keys(dataTypes)[7],
           value: ''
         }
@@ -49,40 +50,40 @@ function TransactionForm({ preset, updateResult }: Props) {
     }
   }
 
-  const createDefaultInstruction = (id: number): InstructionType => {
+  const createDefaultInstruction = (id: string): InstructionType => {
     return {
       'id': id,
       'programId': '',
       'accounts': [{
-        id: 1,
+        id: uuidv4(),
         pubKey: '',
         signer: false,
         writable: false
       }],
       'data': [{
-        id: 1,
+        id: uuidv4(),
         type: Object.keys(dataTypes)[0],
         value: ''
       }]
     }
   }
-  const [nextId, setNextId] = useState(2);
-  const [instructions, setInstructions] = useState([createDefaultInstruction(1)]);
+  const [instructions, setInstructions] = useState([
+    createDefaultInstruction(uuidv4())
+  ]);
   const { connection } = useConnection();
   const { sendTransaction } = useWallet();
 
   useEffect(() => {
     if (preset == 'transfer') {
-      setInstructions([createTransferInstruction(1)])
+      setInstructions([createTransferInstruction(uuidv4())])
     } else {
-      setInstructions([createDefaultInstruction(1)])
+      setInstructions([createDefaultInstruction(uuidv4())])
     }
   }, [preset])
 
   const addInstruction: MouseEventHandler<HTMLButtonElement> = (e) => {
     e.preventDefault();
-    setInstructions([...instructions, createDefaultInstruction(nextId)]);
-    setNextId(nextId + 1);
+    setInstructions([...instructions, createDefaultInstruction(uuidv4())]);
   };
 
   const handleEditInstruction = (instruction: InstructionType) => {
@@ -91,7 +92,7 @@ function TransactionForm({ preset, updateResult }: Props) {
     );
   };
 
-  const handleDeleteInstruction = (id: number) => {
+  const handleDeleteInstruction = (id: string) => {
     setInstructions(instructions.filter((inst) => inst.id !== id));
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,14 @@
         "next": "12.1.6",
         "react": "18.1.0",
         "react-dom": "18.1.0",
-        "react-icons": "^4.4.0"
+        "react-icons": "^4.4.0",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@types/node": "17.0.39",
         "@types/react": "18.0.11",
         "@types/react-dom": "18.0.5",
+        "@types/uuid": "^8.3.4",
         "autoprefixer": "^10.4.7",
         "eslint": "8.17.0",
         "eslint-config-next": "12.1.6",
@@ -560,6 +562,12 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -4539,6 +4547,12 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "@types/ws": {

--- a/package.json
+++ b/package.json
@@ -19,12 +19,14 @@
     "next": "12.1.6",
     "react": "18.1.0",
     "react-dom": "18.1.0",
-    "react-icons": "^4.4.0"
+    "react-icons": "^4.4.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/node": "17.0.39",
     "@types/react": "18.0.11",
     "@types/react-dom": "18.0.5",
+    "@types/uuid": "^8.3.4",
     "autoprefixer": "^10.4.7",
     "eslint": "8.17.0",
     "eslint-config-next": "12.1.6",


### PR DESCRIPTION
Use UUID as ID for Instructions, Accounts, and Data instead of a
counter-based ID. This helps avoid having to manage counter state which
is error-prone especially in the presence of presets.