### PR TITLE
Change preset transaction radio inputs to buttons

### DIFF
--- a/components/PresetTransactionPicker.tsx
+++ b/components/PresetTransactionPicker.tsx
@@ -10,17 +10,9 @@ function PresetTransactionPicker({onChange}: Props) {
   return (
     <div className="flex flex-col gap-3 font-nunito text-white text-xl">
       <label className="text-white">Pick a preset transaction:</label>
-
-      <label className="label cursor-pointer justify-start gap-10">
-        <input
-          type="radio"
-          value="transfer"
-          name="radio-6"
-          className="radio checked:bg-blue-500"
-          onChange={(e) => onChange(e.target.value)}
-        />
-        <span className="label-text">Transfer</span>
-      </label>
+      <button className="btn" onClick={() => onChange('transfer')}>
+        Transfer
+      </button>
     </div>
   )
 }

--- a/components/TransactionForm.tsx
+++ b/components/TransactionForm.tsx
@@ -1,100 +1,24 @@
 import Instructions from './Instructions'
 import { InstructionType } from './Instruction'
 import styles from '../styles/TransactionForm.module.css'
-import { useConnection, useWallet } from '@solana/wallet-adapter-react';
-import { useState, MouseEventHandler, useEffect } from 'react'
+import { useConnection, useWallet  } from '@solana/wallet-adapter-react';
+import { MouseEventHandler } from 'react'
 import { dataTypes } from './DataField'
 import { PublicKey, Transaction, TransactionInstruction } from '@solana/web3.js';
 import { struct } from '@solana/buffer-layout';
-import { v4 as uuidv4 } from 'uuid';
 
 interface Props {
-  preset: String;
+  instructions: InstructionType[];
   updateResult: Function;
+  addInstruction: Function;
+  deleteInstruction: Function;
+  editInstruction: Function;
 }
 
-function TransactionForm({ preset, updateResult }: Props) {
-  const { publicKey } = useWallet()
+function TransactionForm({ instructions, updateResult, addInstruction, deleteInstruction, editInstruction }: Props) {
 
-  const createTransferInstruction = (id: string): InstructionType => {
-
-    return {
-      'id': id,
-      'programId': '11111111111111111111111111111111',
-      'accounts': [
-        {
-          id: uuidv4(),
-          pubKey: publicKey?.toBase58() || '',
-          signer: true,
-          writable: true
-        },
-        {
-          id: uuidv4(),
-          pubKey: '',
-          signer: false,
-          writable: true
-        }
-      ],
-      'data': [
-        {
-          id: uuidv4(),
-          type: Object.keys(dataTypes)[2],
-          value: '2'
-        },
-        {
-          id: uuidv4(),
-          type: Object.keys(dataTypes)[7],
-          value: ''
-        }
-      ]
-    }
-  }
-
-  const createDefaultInstruction = (id: string): InstructionType => {
-    return {
-      'id': id,
-      'programId': '',
-      'accounts': [{
-        id: uuidv4(),
-        pubKey: '',
-        signer: false,
-        writable: false
-      }],
-      'data': [{
-        id: uuidv4(),
-        type: Object.keys(dataTypes)[0],
-        value: ''
-      }]
-    }
-  }
-  const [instructions, setInstructions] = useState([
-    createDefaultInstruction(uuidv4())
-  ]);
   const { connection } = useConnection();
   const { sendTransaction } = useWallet();
-
-  useEffect(() => {
-    if (preset == 'transfer') {
-      setInstructions([createTransferInstruction(uuidv4())])
-    } else {
-      setInstructions([createDefaultInstruction(uuidv4())])
-    }
-  }, [preset])
-
-  const addInstruction: MouseEventHandler<HTMLButtonElement> = (e) => {
-    e.preventDefault();
-    setInstructions([...instructions, createDefaultInstruction(uuidv4())]);
-  };
-
-  const handleEditInstruction = (instruction: InstructionType) => {
-    setInstructions(instructions.map((inst) =>
-      inst.id === instruction.id ? instruction : inst)
-    );
-  };
-
-  const handleDeleteInstruction = (id: string) => {
-    setInstructions(instructions.filter((inst) => inst.id !== id));
-  };
 
   const submit: MouseEventHandler = async (e) => {
     e.preventDefault();
@@ -153,7 +77,10 @@ function TransactionForm({ preset, updateResult }: Props) {
         <div>
           <button
             className="btn btn-secondary"
-            onClick={addInstruction}
+            onClick={(e) => {
+              e.preventDefault();
+              addInstruction('default');
+            }}
           >
             Add Instruction
           </button>
@@ -167,8 +94,8 @@ function TransactionForm({ preset, updateResult }: Props) {
       <div className="h-full overflow-y-scroll">
         <Instructions
           instructions={instructions}
-          editInstruction={handleEditInstruction}
-          deleteInstruction={handleDeleteInstruction}
+          editInstruction={editInstruction}
+          deleteInstruction={deleteInstruction}
         />
       </div>
 

--- a/pages/main.tsx
+++ b/pages/main.tsx
@@ -1,18 +1,78 @@
-import type { NextPage } from 'next'
 import ClusterPicker from "../components/ClusterPicker";
 import React, { useState } from "react";
 import PresetTransactionPicker from "../components/PresetTransactionPicker";
 import TransactionForm from '../components/TransactionForm'
 import Result from "../components/Result";
+import { v4 as uuidv4 } from 'uuid';
+import { dataTypes } from '../components/DataField';
+import { useWallet } from '@solana/wallet-adapter-react';
+import { InstructionType } from "../components/Instruction";
 
 interface Props {
   setCluster: Function;
   cluster: string;
 }
 
-const Main: React.FC<Props> = ({setCluster, cluster}) => {
+const Main: React.FC<Props> = ({ setCluster, cluster }) => {
+  const { publicKey } = useWallet()
 
-  const [preset, setPreset] = useState("");
+  const presets: { [key: string]: Function } = {
+    'default': () => {
+      return [{
+        'id': uuidv4(),
+        'programId': '',
+        'accounts': [{
+          id: uuidv4(),
+          pubKey: '',
+          signer: false,
+          writable: false
+        }],
+        'data': [{
+          id: uuidv4(),
+          type: Object.keys(dataTypes)[0],
+          value: ''
+        }]
+      }]
+    },
+
+    'transfer': () => {
+      return [{
+        'id': uuidv4(),
+        'programId': '11111111111111111111111111111111',
+        'accounts': [
+          {
+            id: uuidv4(),
+            pubKey: publicKey?.toBase58() || '',
+            signer: true,
+            writable: true
+          },
+          {
+            id: uuidv4(),
+            pubKey: '',
+            signer: false,
+            writable: true
+          }
+        ],
+        'data': [
+          {
+            id: uuidv4(),
+            type: Object.keys(dataTypes)[2],
+            value: '2'
+          },
+          {
+            id: uuidv4(),
+            type: Object.keys(dataTypes)[7],
+            value: ''
+          }
+        ]
+      }]
+    }
+  }
+
+  const [instructions, setInstructions] = useState(
+    presets['default']() as InstructionType[]
+  )
+
   const [result, setResult] = useState({
     status: 'info',
     msg: "[Transaction result]"
@@ -22,15 +82,37 @@ const Main: React.FC<Props> = ({setCluster, cluster}) => {
     setResult(newResult)
   }
 
+  const handleAddInstruction = (preset: string) => {
+    setInstructions(instructions.concat(presets[preset]()));
+  }
+
+  const handleDeleteInstruction = (id: string) => {
+    setInstructions(instructions.filter(inst => inst.id !== id))
+  }
+
+  const handleEditInstruction = (instruction: InstructionType) => {
+    setInstructions(instructions.map(inst =>
+      inst.id === instruction.id ? instruction : inst
+    ))
+  }
+
   return (
     <div className="w-full h-4/5 flex py-2 justify-center items-start">
       <div className="w-1/4 flex flex-col gap-10">
         <ClusterPicker onChange={setCluster} />
-        <PresetTransactionPicker onChange={setPreset} />
+        <PresetTransactionPicker onChange={(preset: string) => {
+          setInstructions(presets[preset]())
+        }} />
       </div>
 
       <div className="w-3/4 h-full pl-4 ml-4 border-l-2 border-gray-500/20">
-        <TransactionForm preset={preset} updateResult={updateResult} />
+        <TransactionForm
+          instructions={instructions}
+          updateResult={updateResult}
+          addInstruction={handleAddInstruction}
+          deleteInstruction={handleDeleteInstruction}
+          editInstruction={handleEditInstruction}
+        />
         <Result result={result} cluster={cluster} />
       </div>
     </div>


### PR DESCRIPTION
- Presets are stored in an array.
- Move up the `instructions` state to the main page component and update
it whenever a preset is clicked.
- Pass down `instructions` and transaction edit handlers from main page component to TranscationForm and handle changes in the main page.